### PR TITLE
libopx_cam: Support new camera.msm8974.so

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -163,7 +163,7 @@ BOARD_USES_QCOM_HARDWARE := true
 TARGET_RIL_VARIANT := caf
 
 #Preload Libs
-TARGET_LDPRELOAD := libNimsWrap.so
+TARGET_LDPRELOAD := libNimsWrap.so:libopx_cam.so
 
 # Recovery
 TARGET_RECOVERY_FSTAB := $(PLATFORM_PATH)/rootdir/etc/fstab.qcom

--- a/libopx_cam/Android.mk
+++ b/libopx_cam/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_SRC_FILES := cam_cli.c
+LOCAL_MODULE := libopx_cam
+LOCAL_MODULE_TAGS := optional
+
+include $(BUILD_SHARED_LIBRARY)

--- a/libopx_cam/cam_cli.c
+++ b/libopx_cam/cam_cli.c
@@ -1,0 +1,1 @@
+const char _ZN7android16CameraParameters12KEY_APP_MASKE[] = "app-mask";

--- a/onyx.mk
+++ b/onyx.mk
@@ -52,6 +52,10 @@ PRODUCT_PACKAGES += \
     init.recovery.qcom.rc \
     ueventd.qcom.rc
 
+# Camera compatibility layer
+PRODUCT_PACKAGES += \
+    libopx_cam
+
 # ANT+
 PRODUCT_PACKAGES += \
     AntHalService \


### PR DESCRIPTION
The vendor camera.msm8974.so requires a symbol missing in CameraParameters.
PRELOAD this lib to get it working for now.